### PR TITLE
Add SiteStreamDevice and SiteDriver for site compilation

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-03-24T09:42:17.551Z for PR creation at branch issue-23-d8180eb4fcd9 for issue https://github.com/xlab2016/space_db_private/issues/23
 # Updated: 2026-04-06T07:13:09.049Z
-# Updated: 2026-04-11T01:47:40.723Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-03-24T09:42:17.551Z for PR creation at branch issue-23-d8180eb4fcd9 for issue https://github.com/xlab2016/space_db_private/issues/23
 # Updated: 2026-04-06T07:13:09.049Z
+# Updated: 2026-04-11T01:47:40.723Z

--- a/examples/simple_site.agi
+++ b/examples/simple_site.agi
@@ -1,0 +1,19 @@
+@AGI 0.0.1;
+
+program simple_site;
+system samples;
+module views;
+
+Site1} : site {
+}
+
+procedure Main() {
+  var frontend := stream<site, Site1>;
+  frontend.open({ port: 6000 });
+
+  await frontend;
+}
+
+entrypoint {
+  Main;
+}

--- a/src/Libs/Magic.Kernel/Core/OS/Hal.cs
+++ b/src/Libs/Magic.Kernel/Core/OS/Hal.cs
@@ -426,6 +426,11 @@ namespace Magic.Kernel.Core.OS
                 defType.Generalizations.Add(new ClawStreamDevice());
                 return defObj;
             }
+            if (streamDevice != null && genSet.Contains("site"))
+            {
+                defType.Generalizations.Add(new Devices.Streams.SiteStreamDevice());
+                return defObj;
+            }
             if (streamDevice != null && genSet.Contains("inference") && genSet.Contains("openai"))
             {
                 defType.Generalizations.Add(new OpenAIInference());
@@ -466,6 +471,8 @@ namespace Magic.Kernel.Core.OS
                 else if (string.Equals(g as string, "client", StringComparison.OrdinalIgnoreCase))
                     ;
                 else if (string.Equals(g as string, "claw", StringComparison.OrdinalIgnoreCase))
+                    ; // handled by combined genSet check above
+                else if (string.Equals(g as string, "site", StringComparison.OrdinalIgnoreCase))
                     ; // handled by combined genSet check above
                 else if (string.Equals(g as string, "inference", StringComparison.OrdinalIgnoreCase))
                     ; // handled by combined genSet checks above

--- a/src/Libs/Magic.Kernel/Devices/Streams/Drivers/SiteDriver.cs
+++ b/src/Libs/Magic.Kernel/Devices/Streams/Drivers/SiteDriver.cs
@@ -1,0 +1,185 @@
+using System.Net;
+using System.Text;
+using Magic.Kernel.Devices;
+
+namespace Magic.Kernel.Devices.Streams.Drivers
+{
+    /// <summary>
+    /// HTTP Site server: listens on a configurable port and returns an empty HTML page for any request.
+    /// Suitable for use as a simple site device in the AGI stream system.
+    /// </summary>
+    public sealed class SiteDriver : IStreamDevice
+    {
+        private int _port;
+        private string _serverName = "site";
+
+        private HttpListener? _listener;
+        private CancellationTokenSource? _cts;
+        private Task? _serverTask;
+        private readonly TaskCompletionSource _stoppedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private static readonly byte[] EmptyHtmlBytes = Encoding.UTF8.GetBytes("<html></html>");
+
+        public int Port => _port;
+
+        public bool IsListening => _listener?.IsListening == true && _serverTask != null && !_serverTask.IsCompleted;
+
+        public void SetServerName(string name)
+        {
+            _serverName = string.IsNullOrWhiteSpace(name) ? "site" : name.Trim();
+        }
+
+        public void ParseAndApplyConfig(object? config)
+        {
+            if (config == null) return;
+
+            if (config is Dictionary<string, object> dict)
+            {
+                if (dict.TryGetValue("port", out var portObj))
+                    _port = ParseInt(portObj, 8080);
+            }
+
+            if (_port <= 0) _port = 8080;
+        }
+
+        public Task<DeviceOperationResult> OpenAsync()
+        {
+            if (_port <= 0) _port = 8080;
+
+            _cts?.Cancel();
+            _cts = new CancellationTokenSource();
+            var token = _cts.Token;
+
+            _listener?.Close();
+            _listener = new HttpListener();
+            _listener.Prefixes.Add($"http://+:{_port}/");
+
+            try
+            {
+                _listener.Start();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[{_serverName}] [site] Failed to start listener on port {_port}: {ex.Message}");
+                return Task.FromResult(DeviceOperationResult.Fail(DeviceOperationState.IOError, ex.Message));
+            }
+
+            Console.WriteLine($"[{_serverName}] [site] Listening on port {_port}");
+
+            _serverTask = Task.Run(() => ServeLoopAsync(token), CancellationToken.None);
+
+            return Task.FromResult(DeviceOperationResult.Success);
+        }
+
+        private async Task ServeLoopAsync(CancellationToken token)
+        {
+            var listener = _listener;
+            if (listener == null) return;
+
+            try
+            {
+                while (!token.IsCancellationRequested && listener.IsListening)
+                {
+                    HttpListenerContext ctx;
+                    try
+                    {
+                        ctx = await listener.GetContextAsync().ConfigureAwait(false);
+                    }
+                    catch (HttpListenerException) when (token.IsCancellationRequested || !listener.IsListening)
+                    {
+                        break;
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        break;
+                    }
+
+                    _ = Task.Run(() => HandleRequestAsync(ctx), CancellationToken.None);
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Console.Error.WriteLine($"[{_serverName}] [site] Server loop error: {ex.Message}");
+            }
+            finally
+            {
+                _stoppedTcs.TrySetResult();
+            }
+        }
+
+        private static async Task HandleRequestAsync(HttpListenerContext ctx)
+        {
+            try
+            {
+                var response = ctx.Response;
+                response.StatusCode = 200;
+                response.ContentType = "text/html; charset=utf-8";
+                response.ContentLength64 = EmptyHtmlBytes.Length;
+
+                await response.OutputStream.WriteAsync(EmptyHtmlBytes, 0, EmptyHtmlBytes.Length).ConfigureAwait(false);
+                response.OutputStream.Close();
+            }
+            catch
+            {
+                // ignore per-request errors
+            }
+        }
+
+        /// <summary>Waits until the server stops (listener closed or cancelled).</summary>
+        public Task AwaitUntilStoppedAsync() => _stoppedTcs.Task;
+
+        public async Task<DeviceOperationResult> CloseAsync()
+        {
+            _cts?.Cancel();
+
+            try
+            {
+                _listener?.Close();
+            }
+            catch { }
+
+            if (_serverTask != null)
+            {
+                try
+                {
+                    await _serverTask.ConfigureAwait(false);
+                }
+                catch { }
+            }
+
+            _stoppedTcs.TrySetResult();
+
+            Console.WriteLine($"[{_serverName}] [site] Stopped.");
+            return DeviceOperationResult.Success;
+        }
+
+        public Task<(DeviceOperationResult Result, byte[] Bytes)> ReadAsync()
+            => Task.FromResult((DeviceOperationResult.NotSupported("SiteDriver does not support Read"), Array.Empty<byte>()));
+
+        public Task<DeviceOperationResult> WriteAsync(byte[] bytes)
+            => Task.FromResult(DeviceOperationResult.NotSupported("SiteDriver does not support Write"));
+
+        public Task<DeviceOperationResult> ControlAsync(DeviceControlBase deviceControl)
+            => Task.FromResult(DeviceOperationResult.NotSupported("SiteDriver does not support Control"));
+
+        public Task<(DeviceOperationResult Result, IStreamChunk? Chunk)> ReadChunkAsync()
+            => Task.FromResult<(DeviceOperationResult, IStreamChunk?)>((DeviceOperationResult.NotSupported("SiteDriver does not support ReadChunk"), null));
+
+        public Task<DeviceOperationResult> WriteChunkAsync(IStreamChunk chunk)
+            => Task.FromResult(DeviceOperationResult.NotSupported("SiteDriver does not support WriteChunk"));
+
+        public Task<DeviceOperationResult> MoveAsync(StructurePosition? position)
+            => Task.FromResult(DeviceOperationResult.NotSupported("SiteDriver does not support Move"));
+
+        public Task<(DeviceOperationResult Result, long Length)> LengthAsync()
+            => Task.FromResult((DeviceOperationResult.NotSupported("SiteDriver does not support Length"), 0L));
+
+        private static int ParseInt(object? obj, int defaultVal)
+        {
+            if (obj is long l) return (int)l;
+            if (obj is int i) return i;
+            if (obj is string s && int.TryParse(s, out var v)) return v;
+            return defaultVal;
+        }
+    }
+}

--- a/src/Libs/Magic.Kernel/Devices/Streams/SiteStreamDevice.cs
+++ b/src/Libs/Magic.Kernel/Devices/Streams/SiteStreamDevice.cs
@@ -1,0 +1,80 @@
+using Magic.Kernel.Devices;
+using Magic.Kernel.Devices.Streams.Drivers;
+using Magic.Kernel.Interpretation;
+
+namespace Magic.Kernel.Devices.Streams
+{
+    /// <summary>
+    /// Site device: an HTTP server that listens on a configurable port and returns an empty HTML page for any request.
+    /// Usage in AGI:
+    /// <code>
+    /// Site1} : site { }
+    ///
+    /// procedure Main() {
+    ///   var frontend := stream&lt;site, Site1&gt;;
+    ///   frontend.open({ port: 6000 });
+    ///   await frontend;
+    /// }
+    /// </code>
+    /// </summary>
+    public class SiteStreamDevice : DefStream
+    {
+        private SiteDriver? _driver;
+
+        public override async Task<object?> CallObjAsync(string methodName, object?[] args)
+        {
+            var name = methodName?.Trim() ?? "";
+
+            if (string.Equals(name, "open", StringComparison.OrdinalIgnoreCase))
+                return await HandleOpenAsync(args).ConfigureAwait(false);
+
+            throw new CallUnknownMethodException(name, this);
+        }
+
+        private async Task<DeviceOperationResult> HandleOpenAsync(object?[]? args)
+        {
+            _driver ??= new SiteDriver();
+            _driver.SetServerName(Name);
+            if (args != null && args.Length > 0)
+                _driver.ParseAndApplyConfig(args[0]);
+
+            return await _driver.OpenAsync().ConfigureAwait(false);
+        }
+
+        private IStreamDevice Driver => _driver ?? throw new InvalidOperationException("Device not opened. Call site.open first.");
+
+        public override Task<DeviceOperationResult> OpenAsync() => Driver.OpenAsync();
+
+        public override async Task<object?> AwaitObjAsync()
+        {
+            if (_driver != null)
+                await _driver.AwaitUntilStoppedAsync().ConfigureAwait(false);
+            return this;
+        }
+
+        public override Task<object?> Await() => AwaitObjAsync();
+
+        public override async Task<DeviceOperationResult> CloseAsync()
+        {
+            try
+            {
+                if (_driver != null)
+                    await _driver.CloseAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                UnregisterFromStreamRegistry();
+            }
+
+            return DeviceOperationResult.Success;
+        }
+
+        public override Task<(DeviceOperationResult Result, byte[] Bytes)> ReadAsync() => Driver.ReadAsync();
+        public override Task<DeviceOperationResult> WriteAsync(byte[] bytes) => Driver.WriteAsync(bytes);
+        public override Task<DeviceOperationResult> ControlAsync(DeviceControlBase deviceControl) => Driver.ControlAsync(deviceControl);
+        public override Task<(DeviceOperationResult Result, IStreamChunk? Chunk)> ReadChunkAsync() => Driver.ReadChunkAsync();
+        public override Task<DeviceOperationResult> WriteChunkAsync(IStreamChunk chunk) => Driver.WriteChunkAsync(chunk);
+        public override Task<DeviceOperationResult> MoveAsync(StructurePosition? position) => Driver.MoveAsync(position);
+        public override Task<(DeviceOperationResult Result, long Length)> LengthAsync() => Driver.LengthAsync();
+    }
+}


### PR DESCRIPTION
## Summary

Implements issue #41: adds compilation and interpretation for the `site` stream type in the AGI language.

### What was added

- **`SiteDriver`** (`src/Libs/Magic.Kernel/Devices/Streams/Drivers/SiteDriver.cs`):
  HTTP server using `HttpListener`. Listens on a configurable port and returns an empty HTML page (`<html></html>`, `Content-Type: text/html`) for any request.

- **`SiteStreamDevice`** (`src/Libs/Magic.Kernel/Devices/Streams/SiteStreamDevice.cs`):
  DefStream wrapper that provides the AGI interface. Handles `open({ port: N })` to start the server and `await` to block until the server is stopped. Follows the same pattern as `ClawStreamDevice`.

- **`Hal.cs`** — registers `site` generalization in `DefGen()`:
  ```csharp
  if (streamDevice != null && genSet.Contains("site"))
  {
      defType.Generalizations.Add(new Devices.Streams.SiteStreamDevice());
      return defObj;
  }
  ```

- **`examples/simple_site.agi`** — example matching the issue's code snippet:
  ```
  program simple_site;
  system samples;
  module views;

  Site1} : site {
  }

  procedure Main() {
    var frontend := stream<site, Site1>;
    frontend.open({ port: 6000 });
    await frontend;
  }

  entrypoint {
    Main;
  }
  ```

### How it works

1. `stream<site, Site1>` creates a `SiteStreamDevice` via `Hal.DefGen()`.
2. `frontend.open({ port: 6000 })` starts an `HttpListener` on port 6000.
3. Any HTTP request to `http://localhost:6000/` receives a `200 OK` response with `<html></html>`.
4. `await frontend` blocks until the server is stopped (e.g., by process shutdown).

## Test plan

- [ ] Run `examples/simple_site.agi` through the interpreter
- [ ] Verify `http://localhost:6000/` returns `200 OK` with `Content-Type: text/html` and body `<html></html>`
- [ ] Verify `await frontend` keeps the process alive until manually stopped
- [ ] Build passes: `dotnet build src/Libs/Magic.Kernel/Magic.Kernel.csproj` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes xlab2016/space_db_private#41